### PR TITLE
chore: update GitHub URLs to point to Node.js org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,28 @@
 
 - Use Node.js core `require.resolve()`, rather than `require('resolve').sync()`, when available.
   This can be a performance improvement.
-  (https://github.com/elastic/require-in-the-middle/pull/96)
+  (https://github.com/nodejs/require-in-the-middle/pull/96)
 
 ## v7.4.0
 
 - Support hooking built-in Node.js loaded via
   [`process.getBuiltinModule`](https://nodejs.org/api/all.html#all_process_processgetbuiltinmoduleid),
   added in v22.3.0.
-  (https://github.com/elastic/require-in-the-middle/pull/92)
+  (https://github.com/nodejs/require-in-the-middle/pull/92)
 
 ## v7.3.0
 
 - Module name args passed to a `Hook` will now match against package
   entry points defined by "exports" in package.json.
   https://nodejs.org/api/packages.html#package-entry-points
-  (https://github.com/elastic/require-in-the-middle/pull/82)
+  (https://github.com/nodejs/require-in-the-middle/pull/82)
 
 
 ## v7.2.1
 
 - Fix a limitation so that a single `Hook` can hook a module and a sub-module,
   e.g. `new Hook(['example', 'example/some-sub-module'], ...)`.
-  (https://github.com/elastic/require-in-the-middle/pull/84)
+  (https://github.com/nodejs/require-in-the-middle/pull/84)
 
 
 ## v7.2.0
@@ -33,7 +33,7 @@
 - Improve performance (possibly significantly) when using the Hook without
   a modules argument, e.g. `new Hook(null, onrequire)`, by caching exports
   in more cases. Contributed by @nwalters512.
-  (https://github.com/elastic/require-in-the-middle/issues/75)
+  (https://github.com/nodejs/require-in-the-middle/issues/75)
 
 
 ## v7.1.1
@@ -42,20 +42,20 @@
   module does not appear in `require.cache`. This can only happen if there
   is some other `require` hook in play -- e.g. `@babel/register` which is
   used by `@babel/cli`, aka the `babel-node` command.
-  (https://github.com/elastic/require-in-the-middle/issues/72)
+  (https://github.com/nodejs/require-in-the-middle/issues/72)
 
 
 ## v7.1.0
 
 - Add [TypeScript types](./types/index.d.ts).
-  (https://github.com/elastic/require-in-the-middle/pull/67)
+  (https://github.com/nodejs/require-in-the-middle/pull/67)
 
 
 ## v7.0.1
 
 - Fix hooking of 'http2' with Node.js versions [8.0, 8.8) where the 'http2'
   built-in module was behind the `--expose-http2` flag.
-  (https://github.com/elastic/require-in-the-middle/pull/68)
+  (https://github.com/nodejs/require-in-the-middle/pull/68)
   Release v7.0.0 introduced a bug with this case where the process would crash with:
 
     ```
@@ -90,7 +90,7 @@
   to trigger a re-load (and re-run of the hook's `onrequire`) of a module the
   next time it is required -- as mentioned at
   https://nodejs.org/docs/latest/api/all.html#all_modules_requirecache
-  (https://github.com/elastic/require-in-the-middle/issues/61)
+  (https://github.com/nodejs/require-in-the-middle/issues/61)
 
 - (SEMVER-MAJOR) Remove the `hook.cache` field. In earlier versions this was
   available and some tests used it. However it was never a documented field.
@@ -98,29 +98,29 @@
 - If resolving the filename for a `require(...)` fails, defer to the wrapped
   require implementation rather than failing right away. This allows a
   possibly-monkey-patched `require` to do its own special thing.
-  (https://github.com/elastic/require-in-the-middle/pull/59)
+  (https://github.com/nodejs/require-in-the-middle/pull/59)
 
 ## v6.0.0
 
 - Drop Node.js 6 support. New minimum supported Node.js version is 8.6.0.
-  (This is the minimum supported Node.js version for elastic-apm-node@3 that uses
+  (This is the minimum supported Node.js version for nodejs-apm-node@3 that uses
   this module.)
 - Add testing of Node.js 19.
 - Rename default branch from `master` to `main`.
 - Should there be a need to do 5.x maintenance releases there is a
-  [5.x branch](https://github.com/elastic/require-in-the-middle/tree/5.x).
+  [5.x branch](https://github.com/nodejs/require-in-the-middle/tree/5.x).
 
 ## v5.2.0
 
 - Add support for hooking into the require of Node core modules prefixed with
   'node:', e.g. `require('node:http')`. See https://nodejs.org/api/modules.html#core-modules
-  (https://github.com/elastic/require-in-the-middle/pull/53)
+  (https://github.com/nodejs/require-in-the-middle/pull/53)
 
 ## v5.1.0
 
 - Add support for hooking into require of absolute paths.
-  (https://github.com/elastic/require-in-the-middle/issues/43)
+  (https://github.com/nodejs/require-in-the-middle/issues/43)
 
 ## earlier versions
 
-Use the [source](https://github.com/elastic/require-in-the-middle/commits/), Luke.
+Use the [source](https://github.com/nodejs/require-in-the-middle/commits/), Luke.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@
 ## v6.0.0
 
 - Drop Node.js 6 support. New minimum supported Node.js version is 8.6.0.
-  (This is the minimum supported Node.js version for nodejs-apm-node@3 that uses
+  (This is the minimum supported Node.js version for elastic-apm-node@3 that uses
   this module.)
 - Add testing of Node.js 19.
 - Rename default branch from `master` to `main`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Hook into the Node.js `require` function. This allows you to modify
 modules on-the-fly as they are being required.
 
 [![npm](https://img.shields.io/npm/v/require-in-the-middle.svg)](https://www.npmjs.com/package/require-in-the-middle)
-[![Test status](https://github.com/elastic/require-in-the-middle/workflows/Test/badge.svg)](https://github.com/elastic/require-in-the-middle/actions)
+[![Test status](https://github.com/nodejs/require-in-the-middle/workflows/Test/badge.svg)](https://github.com/nodejs/require-in-the-middle/actions)
 
 Also supports hooking into calls to `process.getBuiltinModule()`, which was introduced in Node.js v22.3.0.
 
@@ -77,4 +77,4 @@ subsequent calls to `require()` or `process.getBuiltinModule()`.
 
 ## License
 
-[MIT](https://github.com/elastic/require-in-the-middle/blob/master/LICENSE)
+[MIT](https://github.com/nodejs/require-in-the-middle/blob/master/LICENSE)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/elastic/require-in-the-middle.git"
+    "url": "git+https://github.com/nodejs/require-in-the-middle.git"
   },
   "keywords": [
     "require",
@@ -49,9 +49,9 @@
   "author": "Thomas Watson Steen <w@tson.dk> (https://twitter.com/wa7son)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/elastic/require-in-the-middle/issues"
+    "url": "https://github.com/nodejs/require-in-the-middle/issues"
   },
-  "homepage": "https://github.com/elastic/require-in-the-middle#readme",
+  "homepage": "https://github.com/nodejs/require-in-the-middle#readme",
   "engines": {
     "node": ">=8.6.0"
   }

--- a/test/require-cache-inval.js
+++ b/test/require-cache-inval.js
@@ -2,7 +2,7 @@
 
 // Test support for triggering a reload/re-patch of a module by deleting it
 // from `require.cache`.
-// (https://github.com/elastic/require-in-the-middle/pull/63)
+// (https://github.com/nodejs/require-in-the-middle/pull/63)
 
 const test = require('tape')
 


### PR DESCRIPTION
The GitHub repo was just moved from the `elastic` to the `nodejs` org on GitHub. For details, see: https://github.com/nodejs/admin/issues/890