### PR TITLE
chore: update copyright going forward

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ The MIT License (MIT)
 
 Copyright (c) 2016-2019, Thomas Watson Steen
 Copyright (c) 2019-2025, Elasticsearch B.V.
+Copyright (c) 2025+, require-in-the-middle contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Looking at the other repos under the `nodejs` org, it seems that this is the strategy for copyright. But I might be mistaken